### PR TITLE
Stream iCub camera views to Open MCT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ iCubTelemVizServer/node_modules/*
 iCubTelemVizServer/npm-debug.log
 openmctStaticServer/node_modules/*
 openmctStaticServer/npm-debug.log
+.idea
 .DS_Store

--- a/iCubTelemVizServer/.idea/runConfigurations/iCubTelemChromeClient.xml
+++ b/iCubTelemVizServer/.idea/runConfigurations/iCubTelemChromeClient.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="iCubTelemChromeClient" type="JavascriptDebugType" uri="http://localhost:3000">
+    <method v="2" />
+  </configuration>
+</component>

--- a/iCubTelemVizServer/.idea/runConfigurations/iCubTelemServerAttachToNode.xml
+++ b/iCubTelemVizServer/.idea/runConfigurations/iCubTelemServerAttachToNode.xml
@@ -1,0 +1,6 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="iCubTelemServerAttachToNode" type="ChromiumRemoteDebugType" factoryName="Chromium Remote" port="5858" isV8Legacy="true">
+    <option name="v8Legacy" value="true" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/iCubTelemVizServer/.idea/runConfigurations/iCubTelemServerNode.xml
+++ b/iCubTelemVizServer/.idea/runConfigurations/iCubTelemServerNode.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="iCubTelemServerNode" type="NodeJSConfigurationType" singleton="false" node-parameters="--debug-brk=5858" path-to-js-file="iCubTelemVizServer.js" working-dir="$PROJECT_DIR$">
+    <method v="2" />
+  </configuration>
+</component>

--- a/iCubTelemVizServer/.idea/runConfigurations/iCubTelemServerStart.xml
+++ b/iCubTelemVizServer/.idea/runConfigurations/iCubTelemServerStart.xml
@@ -1,0 +1,14 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="iCubTelemServerStart" type="js.build_tools.npm" singleton="false">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="start" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs>
+      <env name="NODE_DEBUG_OPTION" value="--debug" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/iCubTelemVizServer/getDataURIscheme.js
+++ b/iCubTelemVizServer/getDataURIscheme.js
@@ -1,0 +1,61 @@
+// Copy of yarp.getImageSrc
+function getDataURIscheme(compression_type,image_buffer)
+{
+    return 'data:image/'+compression_type+';base64,' + base64ArrayBuffer(image_buffer);
+}
+
+// Copy of yarp.base64ArrayBuffer
+function base64ArrayBuffer(arrayBuffer)
+{
+    var base64    = ''
+    var encodings = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+    var bytes         = new Uint8Array(arrayBuffer)
+    var byteLength    = bytes.byteLength
+    var byteRemainder = byteLength % 3
+    var mainLength    = byteLength - byteRemainder
+
+    var a, b, c, d
+    var chunk
+
+    // Main loop deals with bytes in chunks of 3
+    for (var i = 0; i < mainLength; i = i + 3) {
+        // Combine the three bytes into a single integer
+        chunk = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2]
+
+        // Use bitmasks to extract 6-bit segments from the triplet
+        a = (chunk & 16515072) >> 18 // 16515072 = (2^6 - 1) << 18
+        b = (chunk & 258048)   >> 12 // 258048   = (2^6 - 1) << 12
+        c = (chunk & 4032)     >>  6 // 4032     = (2^6 - 1) << 6
+        d = chunk & 63               // 63       = 2^6 - 1
+
+        // Convert the raw binary segments to the appropriate ASCII encoding
+        base64 += encodings[a] + encodings[b] + encodings[c] + encodings[d]
+    }
+
+    // Deal with the remaining bytes and padding
+    if (byteRemainder == 1) {
+        chunk = bytes[mainLength]
+
+        a = (chunk & 252) >> 2 // 252 = (2^6 - 1) << 2
+
+        // Set the 4 least significant bits to zero
+        b = (chunk & 3)   << 4 // 3   = 2^2 - 1
+
+        base64 += encodings[a] + encodings[b] + '=='
+    } else if (byteRemainder == 2) {
+        chunk = (bytes[mainLength] << 8) | bytes[mainLength + 1]
+
+        a = (chunk & 64512) >> 10 // 64512 = (2^6 - 1) << 10
+        b = (chunk & 1008)  >>  4 // 1008  = (2^6 - 1) << 4
+
+        // Set the 2 least significant bits to zero
+        c = (chunk & 15)    <<  2 // 15    = 2^4 - 1
+
+        base64 += encodings[a] + encodings[b] + encodings[c] + '='
+    }
+
+    return base64
+}
+
+module.exports = getDataURIscheme;

--- a/iCubTelemVizServer/getDataURIscheme.js
+++ b/iCubTelemVizServer/getDataURIscheme.js
@@ -10,7 +10,7 @@ function base64ArrayBuffer(arrayBuffer)
     var base64    = ''
     var encodings = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
 
-    var bytes         = new Uint8Array(arrayBuffer)
+    var bytes         = arrayBuffer // 'arrayBuffer' is already of type 'Uint8Array'
     var byteLength    = bytes.byteLength
     var byteRemainder = byteLength % 3
     var mainLength    = byteLength - byteRemainder

--- a/iCubTelemVizServer/iCubTelemVizServer.js
+++ b/iCubTelemVizServer/iCubTelemVizServer.js
@@ -52,7 +52,8 @@ app.use('/history', historyServer);
 var portInConfig = {
     "sens.imu": {"yarpName":'/icubSim/inertial', "localName":'/yarpjs/inertial:i',"portType":'bottle'},
     "sens.camLeftEye": {"yarpName":'/icubSim/camLeftEye', "localName":'/yarpjs/camLeftEye:i',"portType":'image'},
-    "sens.camRightEye": {"yarpName":'/icubSim/camRightEye', "localName":'/yarpjs/camRightEye:i',"portType":'image'}
+    "sens.camRightEye": {"yarpName":'/icubSim/camRightEye', "localName":'/yarpjs/camRightEye:i',"portType":'image'},
+    "sens.leftLegState": {"yarpName":'/icubSim/left_leg/stateExt:o', "localName":'/yarpjs/left_leg/stateExt:o',"portType":'bottle'},
 };
 
 // Open the ports, register read callback functions, connect the ports

--- a/iCubTelemVizServer/iCubTelemVizServer.js
+++ b/iCubTelemVizServer/iCubTelemVizServer.js
@@ -64,10 +64,14 @@ Object.keys(portInConfig).forEach(function (id) {
     var portIn = yarp.portHandler.open(portInConfig[id]["localName"],portInConfig[id]["portType"]);
     switch (portInConfig[id]["portType"]) {
         case 'bottle':
-            portIn.onRead(function (bottle){ icubtelemetry.updateState(id,bottle.toArray()); });
+            portIn.onRead(function (bottle){
+                cubtelemetry.updateState(id,bottle.toArray());
+            });
             break;
         case 'image':
-            portIn.onRead(function (image){ icubtelemetry.updateState(id,getDataURIscheme(image.compression_type,image.buffer)); });
+            portIn.onRead(function (image){
+                icubtelemetry.updateState(id,getDataURIscheme(image.getCompressionType(),image.toBinary()));
+            });
             break;
         default:
     }

--- a/iCubTelemVizServer/iCubTelemVizServer.js
+++ b/iCubTelemVizServer/iCubTelemVizServer.js
@@ -51,9 +51,9 @@ app.use('/history', historyServer);
 // Define the ports
 var portInConfig = {
     "sens.imu": {"yarpName":'/icubSim/inertial', "localName":'/yarpjs/inertial:i',"portType":'bottle'},
-    "sens.camLeftEye": {"yarpName":'/icubSim/camLeftEye', "localName":'/yarpjs/camLeftEye:i',"portType":'image'},
-    "sens.camRightEye": {"yarpName":'/icubSim/camRightEye', "localName":'/yarpjs/camRightEye:i',"portType":'image'},
     "sens.leftLegState": {"yarpName":'/icubSim/left_leg/stateExt:o', "localName":'/yarpjs/left_leg/stateExt:o',"portType":'bottle'},
+    "sens.camLeftEye": {"yarpName":'/icubSim/camLeftEye', "localName":'/yarpjs/camLeftEye:i',"portType":'image'},
+    "sens.camRightEye": {"yarpName":'/icubSim/camRightEye', "localName":'/yarpjs/camRightEye:i',"portType":'image'}
 };
 
 // Open the ports, register read callback functions, connect the ports

--- a/iCubTelemVizServer/iCubTelemVizServer.js
+++ b/iCubTelemVizServer/iCubTelemVizServer.js
@@ -35,6 +35,9 @@ var ICubTelemetry = require('./icubtelemetry');
 var RealtimeServer = require('./realtime-server');
 var HistoryServer = require('./history-server');
 
+// Handle Data URI Scheme
+var getDataURIscheme = require('./getDataURIscheme');
+
 // Setup 'express-ws' in order to add WebSocket routes
 var expressWs = require('express-ws');
 expressWs(app);
@@ -64,7 +67,7 @@ Object.keys(portInConfig).forEach(function (id) {
             portIn.onRead(function (bottle){ icubtelemetry.updateState(id,bottle.toArray()); });
             break;
         case 'image':
-            portIn.onRead(function (image){ icubtelemetry.updateState(id,image); });
+            portIn.onRead(function (image){ icubtelemetry.updateState(id,getDataURIscheme(image.compression_type,image.buffer)); });
             break;
         default:
     }

--- a/iCubTelemVizServer/iCubTelemVizServer.js
+++ b/iCubTelemVizServer/iCubTelemVizServer.js
@@ -78,5 +78,5 @@ app.listen(portTelemetryRespOrigin, function () {
 
 // start the server!
 http.listen(3000, function(){
-  console.log('listening on *:3000');
+  console.log('listening on http://localhost:3000');
 });

--- a/iCubTelemVizServer/icubtelemetry.js
+++ b/iCubTelemVizServer/icubtelemetry.js
@@ -94,7 +94,14 @@ ICubTelemetry.prototype.updateState = function (id,sensorSample) {
 ICubTelemetry.prototype.generateTelemetry = function () {
     var timestamp = Date.now();
     Object.keys(this.state).forEach(function (id) {
-        var telemetrySample = this.flatten({timestamp: timestamp, value: this.state[id], id: id});
+        switch(id) {
+            case "sens.imu":
+            case "sens.leftLegState":
+                var telemetrySample = this.flatten({timestamp: timestamp, value: this.state[id], id: id});
+                break;
+            default:
+                var telemetrySample = {timestamp: timestamp, value: this.state[id], id: id};
+        }
         this.notify(telemetrySample);
         this.history[id].push(telemetrySample);
         if (this.history[id].length > this.maxDepthSamples) {

--- a/iCubTelemVizServer/icubtelemetry.js
+++ b/iCubTelemVizServer/icubtelemetry.js
@@ -20,7 +20,9 @@ function ICubTelemetry() {
           "acc": {"x": 0, "y": 0, "z": 0},
           "gyr": {"x": 0, "y": 0, "z": 0},
           "mag": {"x": 0, "y": 0, "z": 0}
-        }
+        },
+        "sens.camLeftEye": 0,
+        "sens.camRightEye":0
     };
     this.maxDepthSamples = 1000;
     this.history = {};
@@ -53,7 +55,9 @@ ICubTelemetry.prototype.flatten = function (nestedObj) {
   return this.flattenHelper(nestedObj,'');
 }
 
-ICubTelemetry.prototype.updateState = function (sensorSample) {
+ICubTelemetry.prototype.updateState = function (id,sensorSample) {
+    switch(id) {
+        case "sens.imu":
   this.state["sens.imu"].ori.roll = sensorSample[0];
   this.state["sens.imu"].ori.pitch = sensorSample[1];
   this.state["sens.imu"].ori.yaw = sensorSample[2];
@@ -66,6 +70,12 @@ ICubTelemetry.prototype.updateState = function (sensorSample) {
   this.state["sens.imu"].mag.x = sensorSample[9];
   this.state["sens.imu"].mag.y = sensorSample[10];
   this.state["sens.imu"].mag.z = sensorSample[11];
+            break;
+        case "sens.camLeftEye":
+            this.state["sens.camLeftEye"] = sensorSample;
+            break;
+        default:
+    }
 };
 
 /**

--- a/iCubTelemVizServer/icubtelemetry.js
+++ b/iCubTelemVizServer/icubtelemetry.js
@@ -21,11 +21,11 @@ function ICubTelemetry() {
           "gyr": {"x": 0, "y": 0, "z": 0},
           "mag": {"x": 0, "y": 0, "z": 0}
         },
-        "sens.camLeftEye": 0,
-        "sens.camRightEye": 0,
         "sens.leftLegState": {
             "jointPos": {"l_hip_pitch": 0, "l_hip_roll": 0, "l_hip_yaw": 0, "l_knee": 0, "l_ankle_pitch": 0, "l_ankle_roll": 0}
-        }
+        },
+        "sens.camLeftEye": 0,
+        "sens.camRightEye": 0
     };
     this.maxDepthSamples = 1000;
     this.history = {};
@@ -75,12 +75,12 @@ ICubTelemetry.prototype.updateState = function (id,sensorSample) {
             this.state[id].mag.z = sensorSample[11];
             break;
         case "sens.leftLegState":
-            this.state[id].jointPos.l_hip_pitch = sensorSample[0];
-            this.state[id].jointPos.l_hip_roll = sensorSample[1];
-            this.state[id].jointPos.l_hip_yaw = sensorSample[2];
-            this.state[id].jointPos.l_knee = sensorSample[3];
-            this.state[id].jointPos.l_ankle_pitch = sensorSample[4];
-            this.state[id].jointPos.l_ankle_roll = sensorSample[5];
+            this.state[id].jointPos.l_hip_pitch = sensorSample[0][0];
+            this.state[id].jointPos.l_hip_roll = sensorSample[0][1];
+            this.state[id].jointPos.l_hip_yaw = sensorSample[0][2];
+            this.state[id].jointPos.l_knee = sensorSample[0][3];
+            this.state[id].jointPos.l_ankle_pitch = sensorSample[0][4];
+            this.state[id].jointPos.l_ankle_roll = sensorSample[0][5];
             break;
         default:
             this.state[id] = sensorSample;

--- a/iCubTelemVizServer/icubtelemetry.js
+++ b/iCubTelemVizServer/icubtelemetry.js
@@ -22,7 +22,10 @@ function ICubTelemetry() {
           "mag": {"x": 0, "y": 0, "z": 0}
         },
         "sens.camLeftEye": 0,
-        "sens.camRightEye":0
+        "sens.camRightEye": 0,
+        "sens.leftLegState": {
+            "jointPos": {"l_hip_pitch": 0, "l_hip_roll": 0, "l_hip_yaw": 0, "l_knee": 0, "l_ankle_pitch": 0, "l_ankle_roll": 0}
+        }
     };
     this.maxDepthSamples = 1000;
     this.history = {};
@@ -58,23 +61,29 @@ ICubTelemetry.prototype.flatten = function (nestedObj) {
 ICubTelemetry.prototype.updateState = function (id,sensorSample) {
     switch(id) {
         case "sens.imu":
-  this.state["sens.imu"].ori.roll = sensorSample[0];
-  this.state["sens.imu"].ori.pitch = sensorSample[1];
-  this.state["sens.imu"].ori.yaw = sensorSample[2];
-  this.state["sens.imu"].acc.x = sensorSample[3];
-  this.state["sens.imu"].acc.y = sensorSample[4];
-  this.state["sens.imu"].acc.z = sensorSample[5];
-  this.state["sens.imu"].gyr.x = sensorSample[6];
-  this.state["sens.imu"].gyr.y = sensorSample[7];
-  this.state["sens.imu"].gyr.z = sensorSample[8];
-  this.state["sens.imu"].mag.x = sensorSample[9];
-  this.state["sens.imu"].mag.y = sensorSample[10];
-  this.state["sens.imu"].mag.z = sensorSample[11];
+            this.state[id].ori.roll = sensorSample[0];
+            this.state[id].ori.pitch = sensorSample[1];
+            this.state[id].ori.yaw = sensorSample[2];
+            this.state[id].acc.x = sensorSample[3];
+            this.state[id].acc.y = sensorSample[4];
+            this.state[id].acc.z = sensorSample[5];
+            this.state[id].gyr.x = sensorSample[6];
+            this.state[id].gyr.y = sensorSample[7];
+            this.state[id].gyr.z = sensorSample[8];
+            this.state[id].mag.x = sensorSample[9];
+            this.state[id].mag.y = sensorSample[10];
+            this.state[id].mag.z = sensorSample[11];
             break;
-        case "sens.camLeftEye":
-            this.state["sens.camLeftEye"] = sensorSample;
+        case "sens.leftLegState":
+            this.state[id].jointPos.l_hip_pitch = sensorSample[0];
+            this.state[id].jointPos.l_hip_roll = sensorSample[1];
+            this.state[id].jointPos.l_hip_yaw = sensorSample[2];
+            this.state[id].jointPos.l_knee = sensorSample[3];
+            this.state[id].jointPos.l_ankle_pitch = sensorSample[4];
+            this.state[id].jointPos.l_ankle_roll = sensorSample[5];
             break;
         default:
+            this.state[id] = sensorSample;
     }
 };
 

--- a/openmctStaticServer/.idea/runConfigurations/visualizerChromeClient.xml
+++ b/openmctStaticServer/.idea/runConfigurations/visualizerChromeClient.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="visualizerChromeClient" type="JavascriptDebugType" uri="http://localhost:8080">
+    <method v="2" />
+  </configuration>
+</component>

--- a/openmctStaticServer/.idea/runConfigurations/visualizerServerStart.xml
+++ b/openmctStaticServer/.idea/runConfigurations/visualizerServerStart.xml
@@ -1,0 +1,14 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="visualizerServerStart" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="start" />
+    </scripts>
+    <node-interpreter value="$USER_HOME$/.nvm/versions/node/v14.17.0/bin/node" />
+    <envs>
+      <env name="NODE_DEBUG_OPTION" value="--debug" />
+    </envs>
+    <method v="2" />
+  </configuration>
+</component>

--- a/openmctStaticServer/dictionary.json
+++ b/openmctStaticServer/dictionary.json
@@ -124,6 +124,40 @@
           }
         }
       ]
+    },
+    {
+      "name": "Camera view Left eye",
+      "key": "sens.camLeftEye",
+      "values": [
+        {
+          "key": "value.camLeftEye",
+          "name": "Cam Left Eye",
+          "format": "image",
+          "hints": {
+            "image": 1,
+            "priority": 1
+          }
+        },
+        {
+          "key": "value.camRightEye",
+          "name": "Cam Right Eye",
+          "format": "image",
+          "hints": {
+            "image": 1,
+            "priority": 1
+          }
+        },
+        {
+          "key": "utc",
+          "source": "timestamp",
+          "name": "Timestamp",
+          "format": "utc",
+          "hints": {
+            "domain": 1,
+            "priority": 0
+          }
+        }
+      ]
     }
   ]
 }

--- a/openmctStaticServer/dictionary.json
+++ b/openmctStaticServer/dictionary.json
@@ -201,7 +201,7 @@
         {
           "key": "value",
           "name": "Cam Left Eye",
-          "format": "imageDownloadName",
+          "format": "image",
           "hints": {
             "image": 1
           }
@@ -224,7 +224,7 @@
         {
           "key": "value",
           "name": "Cam Right Eye",
-          "format": "imageDownloadName",
+          "format": "image",
           "hints": {
             "image": 1
           }

--- a/openmctStaticServer/dictionary.json
+++ b/openmctStaticServer/dictionary.json
@@ -199,9 +199,9 @@
       "key": "sens.camLeftEye",
       "values": [
         {
-          "key": "value.camLeftEye",
+          "key": "value",
           "name": "Cam Left Eye",
-          "format": "image",
+          "format": "imageDownloadName",
           "hints": {
             "image": 1
           }
@@ -219,12 +219,12 @@
     },
     {
       "name": "Camera view Right eye",
-      "key": "sens.camLeftEye",
+      "key": "sens.camRightEye",
       "values": [
         {
-          "key": "value.camRightEye",
+          "key": "value",
           "name": "Cam Right Eye",
-          "format": "image",
+          "format": "imageDownloadName",
           "hints": {
             "image": 1
           }

--- a/openmctStaticServer/dictionary.json
+++ b/openmctStaticServer/dictionary.json
@@ -134,17 +134,7 @@
           "name": "Cam Left Eye",
           "format": "image",
           "hints": {
-            "image": 1,
-            "priority": 1
-          }
-        },
-        {
-          "key": "value.camRightEye",
-          "name": "Cam Right Eye",
-          "format": "image",
-          "hints": {
-            "image": 1,
-            "priority": 1
+            "image": 1
           }
         },
         {
@@ -153,8 +143,99 @@
           "name": "Timestamp",
           "format": "utc",
           "hints": {
-            "domain": 1,
-            "priority": 0
+            "domain": 1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Camera view Right eye",
+      "key": "sens.camLeftEye",
+      "values": [
+        {
+          "key": "value.camRightEye",
+          "name": "Cam Right Eye",
+          "format": "image",
+          "hints": {
+            "image": 1
+          }
+        },
+        {
+          "key": "utc",
+          "source": "timestamp",
+          "name": "Timestamp",
+          "format": "utc",
+          "hints": {
+            "domain": 1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Left leg joint State measurements",
+      "key": "sens.leftLegState",
+      "values": [
+        {
+          "key": "value.jointPos.l_hip_pitch",
+          "name": "Hip Pitch",
+          "units": "degrees",
+          "format": "float",
+          "hints": {
+            "range": 1
+          }
+        },
+        {
+          "key": "value.jointPos.l_hip_roll",
+          "name": "Hip Roll",
+          "units": "degrees",
+          "format": "float",
+          "hints": {
+            "range": 2
+          }
+        },
+        {
+          "key": "value.jointPos.l_hip_yaw",
+          "name": "Hip Yaw",
+          "units": "degrees",
+          "format": "float",
+          "hints": {
+            "range": 3
+          }
+        },
+        {
+          "key": "value.jointPos.l_knee",
+          "name": "Knee",
+          "units": "degrees",
+          "format": "float",
+          "hints": {
+            "range": 4
+          }
+        },
+        {
+          "key": "value.jointPos.l_ankle_pitch",
+          "name": "Ankle Pitch",
+          "units": "degrees",
+          "format": "float",
+          "hints": {
+            "range": 5
+          }
+        },
+        {
+          "key": "value.jointPos.l_ankle_roll",
+          "name": "Ankle Roll",
+          "units": "degrees",
+          "format": "float",
+          "hints": {
+            "range": 6
+          }
+        },
+        {
+          "key": "utc",
+          "source": "timestamp",
+          "name": "Timestamp",
+          "format": "utc",
+          "hints": {
+            "domain": 1
           }
         }
       ]

--- a/openmctStaticServer/dictionary.json
+++ b/openmctStaticServer/dictionary.json
@@ -126,52 +126,6 @@
       ]
     },
     {
-      "name": "Camera view Left eye",
-      "key": "sens.camLeftEye",
-      "values": [
-        {
-          "key": "value.camLeftEye",
-          "name": "Cam Left Eye",
-          "format": "image",
-          "hints": {
-            "image": 1
-          }
-        },
-        {
-          "key": "utc",
-          "source": "timestamp",
-          "name": "Timestamp",
-          "format": "utc",
-          "hints": {
-            "domain": 1
-          }
-        }
-      ]
-    },
-    {
-      "name": "Camera view Right eye",
-      "key": "sens.camLeftEye",
-      "values": [
-        {
-          "key": "value.camRightEye",
-          "name": "Cam Right Eye",
-          "format": "image",
-          "hints": {
-            "image": 1
-          }
-        },
-        {
-          "key": "utc",
-          "source": "timestamp",
-          "name": "Timestamp",
-          "format": "utc",
-          "hints": {
-            "domain": 1
-          }
-        }
-      ]
-    },
-    {
       "name": "Left leg joint State measurements",
       "key": "sens.leftLegState",
       "values": [
@@ -227,6 +181,52 @@
           "format": "float",
           "hints": {
             "range": 6
+          }
+        },
+        {
+          "key": "utc",
+          "source": "timestamp",
+          "name": "Timestamp",
+          "format": "utc",
+          "hints": {
+            "domain": 1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Camera view Left eye",
+      "key": "sens.camLeftEye",
+      "values": [
+        {
+          "key": "value.camLeftEye",
+          "name": "Cam Left Eye",
+          "format": "image",
+          "hints": {
+            "image": 1
+          }
+        },
+        {
+          "key": "utc",
+          "source": "timestamp",
+          "name": "Timestamp",
+          "format": "utc",
+          "hints": {
+            "domain": 1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Camera view Right eye",
+      "key": "sens.camLeftEye",
+      "values": [
+        {
+          "key": "value.camRightEye",
+          "name": "Cam Right Eye",
+          "format": "image",
+          "hints": {
+            "image": 1
           }
         },
         {


### PR DESCRIPTION
We connect the output of the iCub cameras to the telemetry server and the visualizer web client:
- Add iCub 'Camera Views' streaming signals to the telemetry sources
- Add debug configurations => for debugging the Web client (client running on Chrome), the telemetry source server and the server hosting the client.
- Add joint positions telemetry source (iCub left leg) => for validating the ports configuration table (with fields {"Yarp name", "local name", "port type"}).
- Fix the left leg Yarp port data parsing => port data formatted as bottle of bottles.
- Transmit camera views images as Data URI Scheme string samples =>  The data URI Scheme provides a way to include the image data in-line in the server as if it was an external resource; The composer module configuring the plots shall expect an URL to an image file in the "value" field of the telemetry samples.
- Use proper accessors to get Yarp port image sample compression_type and buffer => yarp bindings methods implemented for the web client and the Node.js application are slightly different (image samples are wrapped by `Image` object.